### PR TITLE
Make implementation compilable on Win10 clients

### DIFF
--- a/implementation.cpp
+++ b/implementation.cpp
@@ -2,7 +2,9 @@
 #include "consts.h"
 #include "implementation.h"
 #include <windows.h>
+#include <cstdint> /* necessary for compiling with int32_t on other machines */
 #include <cstdio>
+#define _USE_MATH_DEFINES /* necessary for finding M_PI on other machines */
 #include <cmath>
 
 
@@ -160,7 +162,7 @@ void populateCorners(int num) {
 	}
 
 	long double angle = 0;
-	long double increment = M_TWOPI / num;
+	long double increment = 2.0*M_PI / num;
 	for (int i = 0; i < num; i++) {
 		angle += increment;
 		cornerX[i] = (int)((clientArea.right / 2) + (clientArea.right / 2) * cosl(angle));
@@ -168,7 +170,7 @@ void populateCorners(int num) {
 	}
 #ifdef DEBUG
 	//sanity check, our angle should now be pretty close to 2pi (not exactly cause floating point)
-	printf("expected: %f\n     got: %Lf\n", M_TWOPI, angle);
+	printf("expected: %f\n     got: %Lf\n", 2.0*M_PI, angle);
 #endif
 }
 void doStep(unsigned int n) {


### PR DESCRIPTION
This update will add the necessary libraries and macros that enable
compilation on Windows 10 machines using Visual C++ 17.

@ichbineinNerd I notice that you're using C++, yet a large portion of your code uses C libraries and conventions (printf rather than std::cout, for example).

Even your libraries that you're including (`cstdio`, `cmath`, etc.) are basically ports of C libraries. Are you sure you want to be using a C++ compiler, or would it be simpler to drop down to C?

And if you truly are trying to write a C++ project, then would you like to work with me on porting it to use C++ conventions (classes, cout, namespaces, and proper naming conventions)?